### PR TITLE
config: increase deck memory limits and requests

### DIFF
--- a/manifests/prow/deployments/deck.yaml
+++ b/manifests/prow/deployments/deck.yaml
@@ -85,10 +85,10 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 128M
+            memory: 384M
           requests:
             cpu: 100m
-            memory: 32M
+            memory: 128M
         volumeMounts:
         - mountPath: /etc/config
           name: config


### PR DESCRIPTION
Increases deck memory resources as the pod was going into crash loopback due to memory consumption.