### PR TITLE
Cleanup: Remove layer labels

### DIFF
--- a/hack/label_sync/README.md
+++ b/hack/label_sync/README.md
@@ -11,6 +11,7 @@
 - [Labels that apply to all repos, for both issues and PRs](#labels-that-apply-to-all-repos-for-both-issues-and-prs)
 - [Labels that apply to all repos, only for issues](#labels-that-apply-to-all-repos-only-for-issues)
 - [Labels that apply to all repos, only for PRs](#labels-that-apply-to-all-repos-only-for-prs)
+- [Labels that apply to all repos in 3scale, for both issues and PRs](#labels-that-apply-to-all-repos-in-3scale-for-both-issues-and-prs)
 - [Labels that apply to 3scale-ops/marin3r, only for PRs](#labels-that-apply-to-3scale-opsmarin3r-only-for-prs)
 - [Labels that apply to 3scale/3scale-saas, for both issues and PRs](#labels-that-apply-to-3scale3scale-saas-for-both-issues-and-prs)
 - [Labels that apply to 3scale/platform, for both issues and PRs](#labels-that-apply-to-3scaleplatform-for-both-issues-and-prs)
@@ -74,14 +75,16 @@ That list is available in the `label` configuration section inside the
 
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | ----------- |
-| <a id="kind/bug" href="#kind/bug">`kind/bug`</a> | Categorizes issue or PR as related to a bug.| anyone | |
+| <a id="kind/automation" href="#kind/automation">`kind/automation`</a> | Categorizes issue or PR as related to CI/CD or an automation.| anyone | |
+| <a id="kind/bug" href="#kind/bug">`kind/bug`</a> | Categorizes issue or PR as related to a bug. <br><br> This was previously `bug`, | anyone | |
 | <a id="kind/cleanup" href="#kind/cleanup">`kind/cleanup`</a> | Categorizes issue or PR as related to cleaning up code, process, or technical debt.| anyone | |
-| <a id="kind/documentation" href="#kind/documentation">`kind/documentation`</a> | Categorizes issue or PR as related to documentation.| anyone | |
-| <a id="kind/feature" href="#kind/feature">`kind/feature`</a> | Categorizes issue or PR as related to a new feature.| anyone | |
+| <a id="kind/documentation" href="#kind/documentation">`kind/documentation`</a> | Categorizes issue or PR as related to documentation. <br><br> This was previously `documentation`, | anyone | |
+| <a id="kind/feature" href="#kind/feature">`kind/feature`</a> | Categorizes issue or PR as related to a new feature. <br><br> This was previously `enhancement`, | anyone | |
+| <a id="kind/monitoring" href="#kind/monitoring">`kind/monitoring`</a> | Categorizes issue or PR as related to monitoring. <br><br> This was previously `layer/monitoring`, | anyone | |
 | <a id="lifecycle/frozen" href="#lifecycle/frozen">`lifecycle/frozen`</a> | Indicates that an issue or PR should not be auto-closed due to staleness.| anyone | |
 | <a id="needs-env" href="#needs-env">`needs-env`</a> | Indicates a PR or issue lacks a `env/foo` label and requires one.| prow |  [require-matching-label](https://git.k8s.io/test-infra/prow/plugins/require-matching-label) |
 | <a id="needs-kind" href="#needs-kind">`needs-kind`</a> | Indicates a PR or issue lacks a `kind/foo` label and requires one.| prow |  [require-matching-label](https://git.k8s.io/test-infra/prow/plugins/require-matching-label) |
-| <a id="needs-layer" href="#needs-layer">`needs-layer`</a> | Indicates a PR or issue lacks a `layer/foo` label and requires one.| prow |  [require-matching-label](https://git.k8s.io/test-infra/prow/plugins/require-matching-label) |
+| <a id="needs-layer" href="#needs-layer">`needs-layer`</a> | REMOVING. This will be deleted after 2021-04-15 00:00:00 +0000 UTC <br><br> Indicates a PR or issue lacks a `layer/foo` label and requires one.| prow |  [require-matching-label](https://git.k8s.io/test-infra/prow/plugins/require-matching-label) |
 | <a id="needs-priority" href="#needs-priority">`needs-priority`</a> | Indicates a PR or issue lacks a `priority/foo` label and requires one.| prow |  [require-matching-label](https://git.k8s.io/test-infra/prow/plugins/require-matching-label) |
 | <a id="needs-size" href="#needs-size">`needs-size`</a> | Indicates a PR or issue lacks a `size/foo` label and requires one.| prow |  [require-matching-label](https://git.k8s.io/test-infra/prow/plugins/require-matching-label) |
 | <a id="priority/awaiting-more-evidence" href="#priority/awaiting-more-evidence">`priority/awaiting-more-evidence`</a> | Lowest priority. Possibly useful, but not yet enough support to actually get it done.| anyone | |
@@ -90,17 +93,26 @@ That list is available in the `label` configuration section inside the
 | <a id="priority/critical-urgent" href="#priority/critical-urgent">`priority/critical-urgent`</a> | Highest priority. Must be actively worked on as someone's top priority right now.| anyone | |
 | <a id="priority/important-longterm" href="#priority/important-longterm">`priority/important-longterm`</a> | Important over the long term, but may not be staffed and/or may need multiple sprints to complete.| anyone | |
 | <a id="priority/important-soon" href="#priority/important-soon">`priority/important-soon`</a> | Must be staffed and worked on either currently, or very soon, ideally in time for the next sprint.| anyone | |
-| <a id="size/L" href="#size/L">`size/L`</a> | Requires few days to complete the PR or the issue.| anyone | |
-| <a id="size/M" href="#size/M">`size/M`</a> | Requires about a day to complete the PR or the issue.| anyone | |
-| <a id="size/S" href="#size/S">`size/S`</a> | Requires less than a day to complete the PR or the issue.| anyone | |
-| <a id="size/XL" href="#size/XL">`size/XL`</a> | Requires about a week to complete the PR or the issue.| anyone | |
-| <a id="size/XS" href="#size/XS">`size/XS`</a> | Requires less than an hour to complete the PR or the issue.| anyone | |
-| <a id="size/XXL" href="#size/XXL">`size/XXL`</a> | Requires more than a week to complete the PR or the issue.| anyone | |
+| <a id="size/L" href="#size/L">`size/L`</a> | Requires few days to complete the PR or the issue.| humans | |
+| <a id="size/M" href="#size/M">`size/M`</a> | Requires about a day to complete the PR or the issue.| humans | |
+| <a id="size/S" href="#size/S">`size/S`</a> | Requires less than a day to complete the PR or the issue.| humans | |
+| <a id="size/XL" href="#size/XL">`size/XL`</a> | Requires about a week to complete the PR or the issue.| humans | |
+| <a id="size/XS" href="#size/XS">`size/XS`</a> | Requires less than an hour to complete the PR or the issue.| humans | |
+| <a id="size/XXL" href="#size/XXL">`size/XXL`</a> | Requires more than a week to complete the PR or the issue.| humans | |
+| <a id="triage/accepted" href="#triage/accepted">`triage/accepted`</a> | Indicates an issue or PR is ready to be actively worked on.| org members |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="triage/duplicate" href="#triage/duplicate">`triage/duplicate`</a> | Indicates an issue is a duplicate of other open issue. <br><br> This was previously `duplicate`, | humans | |
+| <a id="triage/needs-information" href="#triage/needs-information">`triage/needs-information`</a> | Indicates an issue needs more information in order to work on it.| humans | |
+| <a id="triage/not-reproducible" href="#triage/not-reproducible">`triage/not-reproducible`</a> | Indicates an issue can not be reproduced as described.| humans | |
+| <a id="triage/unresolved" href="#triage/unresolved">`triage/unresolved`</a> | Indicates an issue that can not or will not be resolved. <br><br> This was previously `invalid`, `wontfix`, | humans | |
+| <a id="wg/sre" href="#wg/sre">`wg/sre`</a> | Categorizes issue or PR as related to the SRE working group. <br><br> This was previously `layer/operations`, | anyone | |
 
 ## Labels that apply to all repos, only for issues
 
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | ----------- |
+| <a id="good first issue" href="#good first issue">`good first issue`</a> | Denotes an issue ready for a new contributor.| anyone |  [help](https://git.k8s.io/test-infra/prow/plugins/help) |
+| <a id="help wanted" href="#help wanted">`help wanted`</a> | Denotes an issue that needs help from a contributor.| anyone |  [help](https://git.k8s.io/test-infra/prow/plugins/help) |
+| <a id="question" href="#question">`question`</a> | Categorizes issue as a support question.| human | |
 
 ## Labels that apply to all repos, only for PRs
 
@@ -108,6 +120,14 @@ That list is available in the `label` configuration section inside the
 | ---- | ----------- | -------- | ----------- |
 | <a id="approved" href="#approved">`approved`</a> | Indicates a PR has been approved by an approver from all required OWNERS files.| approvers |  [approve](https://git.k8s.io/test-infra/prow/plugins/approve) |
 | <a id="lgtm" href="#lgtm">`lgtm`</a> | Indicates that a PR is ready to be merged.| reviewers or members |  [lgtm](https://git.k8s.io/test-infra/prow/plugins/lgtm) |
+
+## Labels that apply to all repos in 3scale, for both issues and PRs
+
+| Name | Description | Added By | Prow Plugin |
+| ---- | ----------- | -------- | ----------- |
+| <a id="wg/apicast" href="#wg/apicast">`wg/apicast`</a> | Categorizes issue or PR as related to the apicast working group.| anyone | |
+| <a id="wg/backend" href="#wg/backend">`wg/backend`</a> | Categorizes issue or PR as related to the backend working group. <br><br> This was previously `layer/backend`, | anyone | |
+| <a id="wg/system" href="#wg/system">`wg/system`</a> | Categorizes issue or PR as related to the system working group. <br><br> This was previously `layer/system`, | anyone | |
 
 ## Labels that apply to 3scale-ops/marin3r, only for PRs
 
@@ -138,11 +158,7 @@ That list is available in the `label` configuration section inside the
 | <a id="kind/deploy" href="#kind/deploy">`kind/deploy`</a> | Categorizes issue or PR as related to a deploy.| anyone | |
 | <a id="kind/incident" href="#kind/incident">`kind/incident`</a> | Categorizes issue or PR as related to an incident, outage or postmortem.| anyone | |
 | <a id="kind/maintenance" href="#kind/maintenance">`kind/maintenance`</a> | Categorizes issue or PR as related to maintenance tasks.| anyone | |
-| <a id="layer/application" href="#layer/application">`layer/application`</a> | Categorizes issue or PR as related to the application layer.| anyone | |
-| <a id="layer/backend" href="#layer/backend">`layer/backend`</a> | Categorizes issue or PR as related to the backend layer.| anyone | |
-| <a id="layer/monitoring" href="#layer/monitoring">`layer/monitoring`</a> | Categorizes issue or PR as related to the monitoring layer.| anyone | |
-| <a id="layer/operations" href="#layer/operations">`layer/operations`</a> | Categorizes issue or PR as related to the operations layer.| anyone | |
-| <a id="layer/routing" href="#layer/routing">`layer/routing`</a> | Categorizes issue or PR as related to the routing layer.| anyone | |
-| <a id="layer/storage" href="#layer/storage">`layer/storage`</a> | Categorizes issue or PR as related to the storage layer.| anyone | |
-| <a id="layer/system" href="#layer/system">`layer/system`</a> | Categorizes issue or PR as related to the system layer.| anyone | |
+| <a id="layer/application" href="#layer/application">`layer/application`</a> | REMOVING. This will be deleted after 2021-04-15 00:00:00 +0000 UTC <br><br> Categorizes issue or PR as related to the application layer.| anyone | |
+| <a id="layer/routing" href="#layer/routing">`layer/routing`</a> | REMOVING. This will be deleted after 2021-04-15 00:00:00 +0000 UTC <br><br> Categorizes issue or PR as related to the routing layer.| anyone | |
+| <a id="layer/storage" href="#layer/storage">`layer/storage`</a> | REMOVING. This will be deleted after 2021-04-15 00:00:00 +0000 UTC <br><br> Categorizes issue or PR as related to the storage layer.| anyone | |
 

--- a/hack/label_sync/labels.yaml
+++ b/hack/label_sync/labels.yaml
@@ -71,32 +71,32 @@ default:
       description: Requires few days to complete the PR or the issue.
       color: 1a5587
       target: both
-      addedBy: anyone
+      addedBy: humans
     - name: size/M
       description: Requires about a day to complete the PR or the issue.
       color: 216fb3
       target: both
-      addedBy: anyone
+      addedBy: humans
     - name: size/S
       description: Requires less than a day to complete the PR or the issue.
       color: 93c2ea
       target: both
-      addedBy: anyone
+      addedBy: humans
     - name: size/XL
       description: Requires about a week to complete the PR or the issue.
       color: 5a55a1
       target: both
-      addedBy: anyone
+      addedBy: humans
     - name: size/XS
       description: Requires less than an hour to complete the PR or the issue.
       color: cceef5
       target: both
-      addedBy: anyone
+      addedBy: humans
     - name: size/XXL
       description: Requires more than a week to complete the PR or the issue.
       color: 6f048d
       target: both
-      addedBy: anyone
+      addedBy: humans
     # Lifecycle
     - name: lifecycle/frozen
       description: Indicates that an issue or PR should not be auto-closed due to staleness.

--- a/hack/label_sync/labels.yaml
+++ b/hack/label_sync/labels.yaml
@@ -35,6 +35,11 @@ default:
       color: c7def8
       target: both
       addedBy: anyone
+    - name: kind/automation
+      description: Categorizes issue or PR as related to CI/CD or an automation.
+      color: c7def8
+      target: both
+      addedBy: anyone
     # Priority
     - name: priority/awaiting-more-evidence
       description: Lowest priority. Possibly useful, but not yet enough support to actually get it done.

--- a/hack/label_sync/labels.yaml
+++ b/hack/label_sync/labels.yaml
@@ -40,6 +40,13 @@ default:
       color: c7def8
       target: both
       addedBy: anyone
+    - name: kind/monitoring
+      description: Categorizes issue or PR as related to monitoring.
+      color: c7def8
+      target: both
+      addedBy: anyone
+      previously:
+      - name: layer/monitoring
     # Priority
     - name: priority/awaiting-more-evidence
       description: Lowest priority. Possibly useful, but not yet enough support to actually get it done.
@@ -139,6 +146,37 @@ default:
       target: both
       prowPlugin: require-matching-label
       addedBy: prow
+    # Working groups
+    - name: wg/sre
+      description: Categorizes issue or PR as related to the SRE working group.
+      color: ffbf00
+      target: both
+      addedBy: anyone
+      previously:
+      - name: layer/operations
+orgs:
+  3scale:
+    labels:
+    # Working groups
+    - name: wg/apicast
+      description: Categorizes issue or PR as related to the apicast working group.
+      color: ffbf00
+      target: both
+      addedBy: anyone
+    - name: wg/backend
+      description: Categorizes issue or PR as related to the backend working group.
+      color: ffbf00
+      target: both
+      addedBy: anyone
+      previously:
+      - name: layer/backend
+    - name: wg/system
+      description: Categorizes issue or PR as related to the system working group.
+      color: ffbf00
+      target: both
+      addedBy: anyone
+      previously:
+      - name: layer/system
 repos:
   3scale-ops/marin3r:
     labels:

--- a/hack/label_sync/labels.yaml
+++ b/hack/label_sync/labels.yaml
@@ -115,6 +115,38 @@ default:
       color: d3e2f0
       target: both
       addedBy: anyone
+    # Triage
+    - color: 8fc951
+      description: Indicates an issue or PR is ready to be actively worked on.
+      name: triage/accepted
+      target: both
+      prowPlugin: label
+      addedBy: org members
+    - color: d455d0
+      description: Indicates an issue is a duplicate of other open issue.
+      name: triage/duplicate
+      target: both
+      previously:
+      - name: duplicate
+      addedBy: humans
+    - color: d455d0
+      description: Indicates an issue needs more information in order to work on it.
+      name: triage/needs-information
+      target: both
+      addedBy: humans
+    - color: d455d0
+      description: Indicates an issue can not be reproduced as described.
+      name: triage/not-reproducible
+      target: both
+      addedBy: humans
+    - color: ffffff
+      description: Indicates an issue that can not or will not be resolved.
+      name: triage/unresolved
+      previously:
+      - name: invalid
+      - name: wontfix
+      target: both
+      addedBy: humans
     # Needs
     - name: needs-kind
       description: Indicates a PR or issue lacks a `kind/foo` label and requires one.

--- a/hack/label_sync/labels.yaml
+++ b/hack/label_sync/labels.yaml
@@ -146,6 +146,7 @@ default:
       target: both
       prowPlugin: require-matching-label
       addedBy: prow
+      deleteAfter: 2021-04-15T00:00:00Z
     # Working groups
     - name: wg/sre
       description: Categorizes issue or PR as related to the SRE working group.
@@ -267,38 +268,21 @@ repos:
       target: both
       addedBy: anyone
     # Layer
-    - name: layer/application
-      description: Categorizes issue or PR as related to the application layer.
-      color: ffbf00
-      target: both
-      addedBy: anyone
-    - name: layer/backend
-      description: Categorizes issue or PR as related to the backend layer.
-      color: ffbf00
-      target: both
-      addedBy: anyone
-    - name: layer/monitoring
-      description: Categorizes issue or PR as related to the monitoring layer.
-      color: ffbf00
-      target: both
-      addedBy: anyone
-    - name: layer/operations
-      description: Categorizes issue or PR as related to the operations layer.
-      color: ffbf00
-      target: both
-      addedBy: anyone
-    - name: layer/routing
-      description: Categorizes issue or PR as related to the routing layer.
-      color: ffbf00
-      target: both
-      addedBy: anyone
     - name: layer/storage
       description: Categorizes issue or PR as related to the storage layer.
       color: ffbf00
       target: both
       addedBy: anyone
-    - name: layer/system
-      description: Categorizes issue or PR as related to the system layer.
+      deleteAfter: 2021-04-15T00:00:00Z
+    - name: layer/application
+      description: Categorizes issue or PR as related to the application layer.
       color: ffbf00
       target: both
       addedBy: anyone
+      deleteAfter: 2021-04-15T00:00:00Z
+    - name: layer/routing
+      description: Categorizes issue or PR as related to the routing layer.
+      color: ffbf00
+      target: both
+      addedBy: anyone
+      deleteAfter: 2021-04-15T00:00:00Z

--- a/hack/label_sync/labels.yaml
+++ b/hack/label_sync/labels.yaml
@@ -20,6 +20,8 @@ default:
       color: ee0701
       target: both
       addedBy: anyone
+      previously:
+      - name: bug
     - name: kind/cleanup
       description: Categorizes issue or PR as related to cleaning up code, process, or technical debt.
       color: c7def8
@@ -30,11 +32,15 @@ default:
       color: c7def8
       target: both
       addedBy: anyone
+      previously:
+      - name: documentation
     - name: kind/feature
       description: Categorizes issue or PR as related to a new feature.
       color: c7def8
       target: both
       addedBy: anyone
+      previously:
+      - name: enhancement
     - name: kind/automation
       description: Categorizes issue or PR as related to CI/CD or an automation.
       color: c7def8
@@ -147,6 +153,24 @@ default:
       - name: wontfix
       target: both
       addedBy: humans
+    # Github
+    - color: 7057ff
+      description: Denotes an issue ready for a new contributor.
+      name: 'good first issue'
+      target: issues
+      prowPlugin: help
+      addedBy: anyone
+    - color: 006b75
+      description: Denotes an issue that needs help from a contributor.
+      name: 'help wanted'
+      target: issues
+      prowPlugin: help
+      addedBy: anyone
+    - color: d455d0
+      description: Categorizes issue as a support question.
+      name: question
+      target: issues
+      addedBy: human
     # Needs
     - name: needs-kind
       description: Indicates a PR or issue lacks a `kind/foo` label and requires one.

--- a/manifests/prow/configmaps/plugins.yaml
+++ b/manifests/prow/configmaps/plugins.yaml
@@ -111,7 +111,7 @@ data:
         prs: true
         regexp: ^size/
       - missing_label: needs-env
-        org: 3scale/
+        org: 3scale
         issues: true
         prs: true
         regexp: ^env/

--- a/manifests/prow/configmaps/plugins.yaml
+++ b/manifests/prow/configmaps/plugins.yaml
@@ -115,11 +115,6 @@ data:
         issues: true
         prs: true
         regexp: ^env/
-      - missing_label: needs-layer
-        org: 3scale/platform
-        issues: true
-        prs: true
-        regexp: ^layer/
 
     label:
       additional_labels:
@@ -134,13 +129,6 @@ data:
         - env/dev-eng
         - env/stg-saas
         - env/pro-base
-        - layer/application
-        - layer/backend
-        - layer/monitoring
-        - layer/operations
-        - layer/routing
-        - layer/storage
-        - layer/system
 
     approve:
       - repos:


### PR DESCRIPTION
Part of #12.

- Cleanup the layer labels: some have been deleted and others converted to `wg/` and `kind/`  labels, like `wg/system` or `kind/monitoring`.
- Adds the `triage` labels that may be useful in the future
- Adds the default GitHub labels: some are kept and others converted to `triage/` labels like `wontfix` or `duplicated`

/kind automation
/kind documentation
/priority important-longterm
/label size/s
/assign