### PR TITLE
feat: enable size pluging for PRs

### DIFF
--- a/manifests/prow/configmaps/plugins.yaml
+++ b/manifests/prow/configmaps/plugins.yaml
@@ -26,6 +26,7 @@ data:
       - require-matching-label
       - retitle
       - shrug
+      - size
       - trigger
       - verify-owners
       - welcome
@@ -45,6 +46,7 @@ data:
       - owners-label
       - require-matching-label
       - retitle
+      - size
       - trigger
       - verify-owners
       - wip
@@ -182,6 +184,13 @@ data:
         # StoreTreeHash indicates if tree_hash should be stored inside a comment to detect
         # squashed commits before removing lgtm labels
         store_tree_hash: true
+
+    size:
+        s: 8
+        m: 32
+        l: 128
+        xl: 512
+        xxl: 2048
 
     welcome:
       - repos:


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind automation

#### What this PR does / why we need it:

Enables the `size` plugin to automate the addition of the label `size` to the PRs based on the number of lines. This only affects to the PRs, issues size label should be added manually, based on the estimated time required to complete the issue.

#### Which issue(s) this PR fixes:

Part of #6

/priority important-longterm
/label size/xs
/assign