### PR TITLE
Publish prow webhook through the external router

### DIFF
--- a/manifests/prow/ingresses/prow-hook.yaml
+++ b/manifests/prow/ingresses/prow-hook.yaml
@@ -5,9 +5,11 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-production
     external-dns.alpha.kubernetes.io/hostname: prow-hook.mgmt.3sca.net
-    external-dns.alpha.kubernetes.io/target: prow-hook.apps.pro-base-ocp4.mgmt.3sca.net
+    external-dns.alpha.kubernetes.io/target: prow-hook.external.pro-base-ocp4.mgmt.3sca.net
   name: prow-hook
   namespace: prow
+  labels:
+    type: external
 spec:
   rules:
   - host: prow-hook.mgmt.3sca.net


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Due to the work on https://github.com/3scale/platform/issues/649 we need to explicitly publish this endpoint in a public router as the cluster is now "all private by default".

#### Which issue(s) this PR fixes:

Related to https://github.com/3scale/platform/issues/649
