### PR TITLE
Update plugins.yaml

### DIFF
--- a/manifests/prow/configmaps/plugins.yaml
+++ b/manifests/prow/configmaps/plugins.yaml
@@ -135,6 +135,7 @@ data:
         - env/dev-eng
         - env/stg-saas
         - env/pro-base
+        - env/pro-saas
 
     blunderbuss:
       # ExcludeApprovers controls whether approvers are considered to be


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind automation

#### What this PR does / why we need it:

`pro-saas` label is not defined in the `extra_labels` section of the `labels` prow plugin, so it cannot be defined using `/label env/pro-saas`.


/label size/xs
/assign