### PR TITLE
Fix prow CNAME which is currently pointing to an inexistent OCP router

### DIFF
--- a/manifests/prow/ingresses/prow.yaml
+++ b/manifests/prow/ingresses/prow.yaml
@@ -4,7 +4,7 @@ kind: Ingress
 metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-production
-    external-dns.alpha.kubernetes.io/target: prow.internal.pro-base-ocp4.mgmt.3sca.net
+    external-dns.alpha.kubernetes.io/target: prow.apps.pro-base-ocp4.mgmt.3sca.net
   labels:
     type: internal
   name: prow


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

prow.mgmt.3sca.net is currently not resolving due to a configuration error.

/priority important-longterm
/assign