### PR TITLE
Update prow ingress resources to use new Ingress API

### DIFF
--- a/manifests/prow/ingresses/prow-hook.yaml
+++ b/manifests/prow/ingresses/prow-hook.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -15,10 +15,13 @@ spec:
   - host: prow-hook.mgmt.3sca.net
     http:
       paths:
-      - backend:
-          serviceName: hook
-          servicePort: http
-        path: /hook
+      - path: /hook
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: hook
+            port:
+              name: http
   tls:
   - hosts:
     - prow-hook.mgmt.3sca.net

--- a/manifests/prow/ingresses/prow.yaml
+++ b/manifests/prow/ingresses/prow.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -14,9 +14,12 @@ spec:
   - host: prow.mgmt.3sca.net
     http:
       paths:
-      - backend:
-          serviceName: deck
-          servicePort: http
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: deck
+            port:
+              name: http
   tls:
   - hosts:
     - prow.mgmt.3sca.net


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

It just updates the Ingress API from `v1beta1` to `v1`.

#### Which issue(s) this PR fixes:

Related to https://github.com/3scale/platform/issues/982


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

N/A

#### Additional documentation e.g., usage docs, etc.:

N/A
