### PR TITLE
feat: add prow admin resources

### DIFF
--- a/manifests/prow/clusterroles/aggregate-prow-k8s-io-admin-edit.yaml
+++ b/manifests/prow/clusterroles/aggregate-prow-k8s-io-admin-edit.yaml
@@ -1,0 +1,21 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: aggregate-prow-k8s-io-admin-edit
+rules:
+  - apiGroups:
+      - prow.k8s.io
+    resources:
+      - "*"
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection

--- a/manifests/prow/clusterroles/aggregate-prow-k8s-io-admin-view.yaml
+++ b/manifests/prow/clusterroles/aggregate-prow-k8s-io-admin-view.yaml
@@ -1,0 +1,16 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+  name: aggregate-prow-k8s-io-view
+rules:
+  - apiGroups:
+      - prow.k8s.io
+    resources:
+      - "*"
+    verbs:
+      - get
+      - list
+      - watch

--- a/manifests/prow/crds/prowjobs.yaml
+++ b/manifests/prow/crds/prowjobs.yaml
@@ -1,0 +1,86 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: prowjobs.prow.k8s.io
+spec:
+  additionalPrinterColumns:
+    - JSONPath: .spec.job
+      description: The name of the job being run.
+      name: Job
+      type: string
+    - JSONPath: .status.build_id
+      description: The ID of the job being run.
+      name: BuildId
+      type: string
+    - JSONPath: .spec.type
+      description: The type of job being run.
+      name: Type
+      type: string
+    - JSONPath: .spec.refs.org
+      description: The org for which the job is running.
+      name: Org
+      type: string
+    - JSONPath: .spec.refs.repo
+      description: The repo for which the job is running.
+      name: Repo
+      type: string
+    - JSONPath: .spec.refs.pulls[*].number
+      description: The pulls for which the job is running.
+      name: Pulls
+      type: string
+    - JSONPath: .status.startTime
+      description: When the job started running.
+      name: StartTime
+      type: date
+    - JSONPath: .status.completionTime
+      description: When the job finished running.
+      name: CompletionTime
+      type: date
+    - JSONPath: .status.state
+      description: The state of the job.
+      name: State
+      type: string
+  group: prow.k8s.io
+  names:
+    kind: ProwJob
+    plural: prowjobs
+    singular: prowjob
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            max_concurrency:
+              minimum: 0
+              type: integer
+            type:
+              enum:
+                - presubmit
+                - postsubmit
+                - periodic
+                - batch
+              type: string
+        status:
+          anyOf:
+            - not:
+                properties:
+                  state:
+                    enum:
+                      - success
+                      - failure
+                      - error
+                    type: string
+            - required:
+                - completionTime
+          properties:
+            state:
+              enum:
+                - triggered
+                - pending
+                - success
+                - failure
+                - aborted
+                - error
+              type: string
+  version: v1

--- a/manifests/prow/namespaces/prow-test-pods.yaml
+++ b/manifests/prow/namespaces/prow-test-pods.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    monitoring-key: middleware
+  name: prow-test-pods

--- a/manifests/prow/namespaces/prow.yaml
+++ b/manifests/prow/namespaces/prow.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    monitoring-key: middleware
+    basic-monitoring: enabled
+  name: prow


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds the admin resources required by prow. Those resources were deployed by Hive, but now are managed by ArgoCD after https://github.com/3scale/platform/pull/1058.

/assign
/priority important-soon