### PR TITLE
Feat/Add ingressClassName to prow ingresses

### DIFF
--- a/manifests/prow/ingresses/prow-hook.yaml
+++ b/manifests/prow/ingresses/prow-hook.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     type: external
 spec:
+  ingressClassName: openshift-external
   rules:
   - host: prow-hook.mgmt.3sca.net
     http:

--- a/manifests/prow/ingresses/prow.yaml
+++ b/manifests/prow/ingresses/prow.yaml
@@ -10,6 +10,7 @@ metadata:
   name: prow
   namespace: prow
 spec:
+  ingressClassName: openshift-default
   rules:
   - host: prow.mgmt.3sca.net
     http:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

On OCP versions prior to OCP 4.12, the ingress class election was done via label.

Since OCP 4.12, there is a prometheus alert called **IngressWithoutClassName** that detects if an ingress resource has not set the `ingressClassName`.

This PRs sets the appropiate `ingressClassName` to every prow ingress.


#### Additional documentation e.g., usage docs, etc.:

https://access.redhat.com/solutions/7017955

https://github.com/openshift/enhancements/blob/master/enhancements/ingress/transition-ingress-from-beta-to-stable.md#risks-and-mitigations

/priority important-soon
/assign
