### PR TITLE
Feat/Add prow and prow-hook prometheus HTTP probes to monitor both main endpoints

### DIFF
--- a/manifests/prow/probes/probe-hook.yaml
+++ b/manifests/prow/probes/probe-hook.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: probe-http-priv-ingress-prow-hook
+spec:
+  interval: 30s
+  module: http_prow_hook
+  prober:
+    path: /probe
+    url: 'prometheus-exporter-probe-pro-base-blackbox.prometheus-exporter.svc:9115'
+  targets:
+    staticConfig:
+      static:
+        - 'https://prow-hook.mgmt.3sca.net/hook'

--- a/manifests/prow/probes/probe.yaml
+++ b/manifests/prow/probes/probe.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: probe-http-priv-ingress-prow
+spec:
+  interval: 30s
+  module: http_2xx
+  prober:
+    path: /probe
+    url: 'prometheus-exporter-probe-pro-base-blackbox.prometheus-exporter.svc:9115'
+  targets:
+    staticConfig:
+      static:
+        - 'https://prow.mgmt.3sca.net'


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Right now prow is one of the few components where we have 0 visibility.

This PR adds a couple of HTTP Probes that checks that pro is alive:
- prow: main HTTP endpoint with UI (covering `deck` component)
  - presents a nice view of [recent jobs](https://prow.k8s.io/), [command](https://prow.k8s.io/command-help) and [plugin](https://prow.k8s.io/plugins) help information, the [current status](https://prow.k8s.io/tide) and [history](https://prow.k8s.io/tide-history) of merge automation, and a [dashboard for PR authors](https://prow.k8s.io/pr). 
- prow-hook: specific HTTP endpoint covering the `hook`, which according to official doc is the most important piece
  - is the most important piece. It is a stateless server that listens for GitHub webhooks and dispatches them to the appropriate plugins


## Additional doc

https://docs.prow.k8s.io/docs/components/#core-components

## Related

https://github.com/3scale/platform/pull/1276

/priority important-soon
/assign
