### PR TITLE
Reduce the ok-to-prod label description to 95 chars. 100 is the max

### DIFF
--- a/.github/workflows/label-sync.yaml
+++ b/.github/workflows/label-sync.yaml
@@ -8,6 +8,7 @@ on:
       - main
     paths:
       - 'hack/label_sync/labels.yaml'
+  workflow_dispatch:
 jobs:
 
   sync:

--- a/hack/label_sync/labels.yaml
+++ b/hack/label_sync/labels.yaml
@@ -262,7 +262,7 @@ repos:
     labels:
       # Triggers
       - color: ff0800
-        description: Indicates a PR containing an production ready image has been approved and can be promoted to production.
+        description: Indicates a PR containing an image that has been approved and can be promoted to production.
         name: ok-to-prod
         target: prs
         addedBy: approvers


### PR DESCRIPTION
The `ok-to-prod` had a description field with more than 100 characters, which was causing the workflow to fail.

/kind bug
/priority important-longterm
/assign